### PR TITLE
remove path from heroku stats breakdown

### DIFF
--- a/app.js
+++ b/app.js
@@ -72,7 +72,7 @@ function processLine (line, prefix, defaultTags) {
     if (process.env.DEBUG) {
       console.log('Processing router metrics');
     }
-    let tags = tagsToArr(_.pick(line, ['dyno', 'method', 'status', 'path', 'host', 'code', 'desc', 'at']));
+    let tags = tagsToArr(_.pick(line, ['dyno', 'method', 'status', 'host', 'code', 'desc', 'at']));
     tags = _.union(tags, defaultTags);
     statsd.histogram(prefix + 'heroku.router.request.connect', extractNumber(line.connect), tags);
     statsd.histogram(prefix + 'heroku.router.request.service', extractNumber(line.service), tags);


### PR DESCRIPTION
Continuing the effort to curb unbounded stats count in datadog https://github.com/opendoor-labs/web/pull/12944

heroku-datadog-drain adds stats per-path, but since IDs / tokens are often in paths that mens an unbounded # of stats, which means an unbounded number of dollars to datadog.

<img width="668" alt="screen shot 2017-08-08 at 10 00 56 am" src="https://user-images.githubusercontent.com/14897098/29084339-8a8532c4-7c20-11e7-8f49-af6d0c9b46e6.png">
(10000+ tags..)