### PR TITLE
Revert "add dynotype to dyno metric tags"

### DIFF
--- a/app.js
+++ b/app.js
@@ -57,7 +57,7 @@ function processLine (line, prefix, defaultTags) {
     if (process.env.DEBUG) {
       console.log('Processing dyno metrics');
     }
-    let tags = tagsToArr({ dyno: line.source, dynotype: (line.source || '').split('.')[0] });
+    let tags = tagsToArr({ dyno: line.source });
     tags = _.union(tags, defaultTags);
     let metrics = _.pick(line, (_, key) => key.startsWith('sample#'));
     _.forEach(metrics, function (value, key) {

--- a/app.test.js
+++ b/app.test.js
@@ -42,15 +42,15 @@ describe('Heroku Datadog Drain', function () {
     .expect('OK')
     .then(function () {
       expect(StatsD.prototype.histogram.args).to.deep.equal([
-        ['heroku.router.request.connect', 1, ['dyno:web.1', 'path:/users', 'method:POST', 'status:201', 'host:myapp.com', 'at:info', 'default:tag', 'app:test-app']],
-        ['heroku.router.request.service', 37, ['dyno:web.1', 'path:/users', 'method:POST', 'status:201', 'host:myapp.com', 'at:info', 'default:tag', 'app:test-app']],
-        ['heroku.router.request.connect', 1, ['dyno:web.2', 'path:/users/me/tasks', 'method:GET', 'status:200', 'host:myapp.com', 'at:info', 'default:tag', 'app:test-app']],
-        ['heroku.router.request.service', 64, ['dyno:web.2', 'path:/users/me/tasks', 'method:GET', 'status:200', 'host:myapp.com', 'at:info', 'default:tag', 'app:test-app']],
-        ['heroku.router.request.connect', 6, ['dyno:web.1', 'path:/', 'method:GET', 'status:503', 'host:myapp.com', 'code:H12', 'desc:Request timeout', 'at:error', 'default:tag', 'app:test-app']],
-        ['heroku.router.request.service', 30001, ['dyno:web.1', 'path:/', 'method:GET', 'status:503', 'host:myapp.com', 'code:H12', 'desc:Request timeout', 'at:error', 'default:tag', 'app:test-app']],
+        ['heroku.router.request.connect', 1, ['dyno:web.1', 'method:POST', 'status:201', 'path:/users', 'host:myapp.com', 'at:info', 'default:tag', 'app:test-app']],
+        ['heroku.router.request.service', 37, ['dyno:web.1', 'method:POST', 'status:201', 'path:/users', 'host:myapp.com', 'at:info', 'default:tag', 'app:test-app']],
+        ['heroku.router.request.connect', 1, ['dyno:web.2', 'method:GET', 'status:200', 'path:/users/me/tasks', 'host:myapp.com', 'at:info', 'default:tag', 'app:test-app']],
+        ['heroku.router.request.service', 64, ['dyno:web.2', 'method:GET', 'status:200', 'path:/users/me/tasks', 'host:myapp.com', 'at:info', 'default:tag', 'app:test-app']],
+        ['heroku.router.request.connect', 6, ['dyno:web.1', 'method:GET', 'status:503', 'path:/', 'host:myapp.com', 'code:H12', 'desc:Request timeout', 'at:error', 'default:tag', 'app:test-app']],
+        ['heroku.router.request.service', 30001, ['dyno:web.1', 'method:GET', 'status:503', 'path:/', 'host:myapp.com', 'code:H12', 'desc:Request timeout', 'at:error', 'default:tag', 'app:test-app']],
       ]);
       expect(StatsD.prototype.increment.args).to.deep.equal([
-        ['heroku.router.error', 1, ['dyno:web.1', 'path:/', 'method:GET', 'status:503', 'host:myapp.com', 'code:H12', 'desc:Request timeout', 'at:error', 'default:tag', 'app:test-app']],
+        ['heroku.router.error', 1, ['dyno:web.1', 'method:GET', 'status:503', 'path:/', 'host:myapp.com', 'code:H12', 'desc:Request timeout', 'at:error', 'default:tag', 'app:test-app']],
       ]);
     });
   });
@@ -66,15 +66,15 @@ describe('Heroku Datadog Drain', function () {
     .expect('OK')
     .then(function () {
       expect(StatsD.prototype.histogram.args).to.deep.equal([
-        ['heroku.dyno.load.avg.1m', 0.01, ['dyno:web.1', 'dynotype:web', 'default:tag', 'app:test-app']],
-        ['heroku.dyno.load.avg.5m', 0.02, ['dyno:web.1', 'dynotype:web', 'default:tag', 'app:test-app']],
-        ['heroku.dyno.load.avg.15m', 0.03, ['dyno:web.1', 'dynotype:web', 'default:tag', 'app:test-app']],
-        ['heroku.dyno.memory.total', 103.50, ['dyno:web.1', 'dynotype:web', 'default:tag', 'app:test-app']],
-        ['heroku.dyno.memory.rss', 94.70, ['dyno:web.1', 'dynotype:web', 'default:tag', 'app:test-app']],
-        ['heroku.dyno.memory.cache', 0.32, ['dyno:web.1', 'dynotype:web', 'default:tag', 'app:test-app']],
-        ['heroku.dyno.memory.swap', 8.48, ['dyno:web.1', 'dynotype:web', 'default:tag', 'app:test-app']],
-        ['heroku.dyno.memory.pgpgin', 36091, ['dyno:web.1', 'dynotype:web', 'default:tag', 'app:test-app']],
-        ['heroku.dyno.memory.pgpgout', 11765, ['dyno:web.1', 'dynotype:web', 'default:tag', 'app:test-app']]
+        ['heroku.dyno.load.avg.1m', 0.01, ['dyno:web.1', 'default:tag', 'app:test-app']],
+        ['heroku.dyno.load.avg.5m', 0.02, ['dyno:web.1', 'default:tag', 'app:test-app']],
+        ['heroku.dyno.load.avg.15m', 0.03, ['dyno:web.1', 'default:tag', 'app:test-app']],
+        ['heroku.dyno.memory.total', 103.50, ['dyno:web.1', 'default:tag', 'app:test-app']],
+        ['heroku.dyno.memory.rss', 94.70, ['dyno:web.1', 'default:tag', 'app:test-app']],
+        ['heroku.dyno.memory.cache', 0.32, ['dyno:web.1', 'default:tag', 'app:test-app']],
+        ['heroku.dyno.memory.swap', 8.48, ['dyno:web.1', 'default:tag', 'app:test-app']],
+        ['heroku.dyno.memory.pgpgin', 36091, ['dyno:web.1', 'default:tag', 'app:test-app']],
+        ['heroku.dyno.memory.pgpgout', 11765, ['dyno:web.1', 'default:tag', 'app:test-app']]
       ]);
     });
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
       "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
       "requires": {
-        "mime-types": "~2.1.11",
+        "mime-types": "2.1.15",
         "negotiator": "0.6.1"
       }
     },
@@ -51,14 +51,8 @@
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
       "dev": true,
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
-    },
-    "commander": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
-      "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
-      "dev": true
     },
     "component-emitter": {
       "version": "1.2.1",
@@ -153,12 +147,6 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
-    "escape-string-regexp": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
-      "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
-      "dev": true
-    },
     "etag": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
@@ -169,34 +157,34 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.15.3.tgz",
       "integrity": "sha1-urZdDwOqgMNYQIly/HAPkWlEtmI=",
       "requires": {
-        "accepts": "~1.3.3",
+        "accepts": "1.3.3",
         "array-flatten": "1.1.1",
         "content-disposition": "0.5.2",
-        "content-type": "~1.0.2",
+        "content-type": "1.0.2",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.7",
-        "depd": "~1.1.0",
-        "encodeurl": "~1.0.1",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.0",
-        "finalhandler": "~1.0.3",
+        "depd": "1.1.0",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "etag": "1.8.0",
+        "finalhandler": "1.0.3",
         "fresh": "0.5.0",
         "merge-descriptors": "1.0.1",
-        "methods": "~1.1.2",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.1",
+        "methods": "1.1.2",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.1",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "~1.1.4",
+        "proxy-addr": "1.1.4",
         "qs": "6.4.0",
-        "range-parser": "~1.2.0",
+        "range-parser": "1.2.0",
         "send": "0.15.3",
         "serve-static": "1.12.3",
         "setprototypeof": "1.0.3",
-        "statuses": "~1.3.1",
-        "type-is": "~1.6.15",
+        "statuses": "1.3.1",
+        "type-is": "1.6.15",
         "utils-merge": "1.0.0",
-        "vary": "~1.1.1"
+        "vary": "1.1.1"
       },
       "dependencies": {
         "debug": {
@@ -221,12 +209,12 @@
       "integrity": "sha1-70fneVDpmXgOhgIqVg4yF+DQzIk=",
       "requires": {
         "debug": "2.6.7",
-        "encodeurl": "~1.0.1",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.1",
-        "statuses": "~1.3.1",
-        "unpipe": "~1.0.0"
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.1",
+        "statuses": "1.3.1",
+        "unpipe": "1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -245,9 +233,9 @@
       "integrity": "sha1-ml47kpX5gLJiPPZPojixTOvKcHs=",
       "dev": true,
       "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.5",
-        "mime-types": "^2.1.12"
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.15"
       }
     },
     "formatio": {
@@ -256,7 +244,7 @@
       "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
       "dev": true,
       "requires": {
-        "samsam": "~1.1"
+        "samsam": "1.1.2"
       }
     },
     "formidable": {
@@ -275,16 +263,6 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
       "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44="
     },
-    "glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-      "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
-      "dev": true,
-      "requires": {
-        "inherits": "2",
-        "minimatch": "0.3"
-      }
-    },
     "growl": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
@@ -299,7 +277,7 @@
         "depd": "1.1.0",
         "inherits": "2.0.3",
         "setprototypeof": "1.0.3",
-        "statuses": ">= 1.3.1 < 2"
+        "statuses": "1.3.1"
       }
     },
     "inherits": {
@@ -352,9 +330,9 @@
       "resolved": "https://registry.npmjs.org/logfmt/-/logfmt-1.2.0.tgz",
       "integrity": "sha1-HMwGfBz+ZfPs9YVsCdJlT2kgNXI=",
       "requires": {
-        "lodash": "~2.4.1",
-        "split": "0.2.x",
-        "through": "2.3.x"
+        "lodash": "2.4.2",
+        "split": "0.2.10",
+        "through": "2.3.8"
       },
       "dependencies": {
         "lodash": {
@@ -406,24 +384,8 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
       "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
       "requires": {
-        "mime-db": "~1.27.0"
+        "mime-db": "1.27.0"
       }
-    },
-    "minimatch": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-      "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-      "dev": true,
-      "requires": {
-        "lru-cache": "2",
-        "sigmund": "~1.0.0"
-      }
-    },
-    "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -432,6 +394,14 @@
       "dev": true,
       "requires": {
         "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
       }
     },
     "mocha": {
@@ -452,6 +422,12 @@
         "to-iso-string": "0.0.2"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+          "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+          "dev": true
+        },
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
@@ -461,10 +437,42 @@
             "ms": "0.7.1"
           }
         },
+        "escape-string-regexp": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+          "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+          "dev": true
+        },
+        "glob": {
+          "version": "3.2.11",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "minimatch": "0.3.0"
+          }
+        },
+        "minimatch": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
+          }
+        },
         "ms": {
           "version": "0.7.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
           "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+          "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
           "dev": true
         }
       }
@@ -513,7 +521,7 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.4.tgz",
       "integrity": "sha1-J+VF9pYKRKYn2bREZ+NcG2tM4vM=",
       "requires": {
-        "forwarded": "~0.1.0",
+        "forwarded": "0.1.0",
         "ipaddr.js": "1.3.0"
       }
     },
@@ -533,13 +541,13 @@
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "dev": true,
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~1.0.6",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.0.3",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
       }
     },
     "safe-buffer": {
@@ -560,18 +568,18 @@
       "integrity": "sha1-UBP5+ZAj31DRvZiSwZ4979HVMwk=",
       "requires": {
         "debug": "2.6.7",
-        "depd": "~1.1.0",
-        "destroy": "~1.0.4",
-        "encodeurl": "~1.0.1",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.0",
+        "depd": "1.1.0",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "etag": "1.8.0",
         "fresh": "0.5.0",
-        "http-errors": "~1.6.1",
+        "http-errors": "1.6.1",
         "mime": "1.3.4",
         "ms": "2.0.0",
-        "on-finished": "~2.3.0",
-        "range-parser": "~1.2.0",
-        "statuses": "~1.3.1"
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.3.1"
       },
       "dependencies": {
         "debug": {
@@ -589,9 +597,9 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.3.tgz",
       "integrity": "sha1-n0uhni8wMMVH+K+ZEHg47DjVseI=",
       "requires": {
-        "encodeurl": "~1.0.1",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.1",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.1",
         "send": "0.15.3"
       }
     },
@@ -615,7 +623,7 @@
         "formatio": "1.1.1",
         "lolex": "1.3.2",
         "samsam": "1.1.2",
-        "util": ">=0.10.3 <1"
+        "util": "0.10.3"
       }
     },
     "split": {
@@ -623,7 +631,7 @@
       "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz",
       "integrity": "sha1-Zwl8YB1pfOE2j0GPBs0gHPBSGlc=",
       "requires": {
-        "through": "2"
+        "through": "2.3.8"
       }
     },
     "statuses": {
@@ -637,7 +645,7 @@
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.1"
       }
     },
     "superagent": {
@@ -646,16 +654,16 @@
       "integrity": "sha1-M2GjlxVnUEw1EGOr6q4PqiPb8/g=",
       "dev": true,
       "requires": {
-        "component-emitter": "^1.2.0",
-        "cookiejar": "^2.0.6",
-        "debug": "^2.2.0",
-        "extend": "^3.0.0",
-        "form-data": "^2.1.1",
-        "formidable": "^1.1.1",
-        "methods": "^1.1.1",
-        "mime": "^1.3.4",
-        "qs": "^6.1.0",
-        "readable-stream": "^2.0.5"
+        "component-emitter": "1.2.1",
+        "cookiejar": "2.1.1",
+        "debug": "2.6.8",
+        "extend": "3.0.1",
+        "form-data": "2.2.0",
+        "formidable": "1.1.1",
+        "methods": "1.1.2",
+        "mime": "1.3.4",
+        "qs": "6.4.0",
+        "readable-stream": "2.3.3"
       }
     },
     "supertest": {
@@ -664,8 +672,8 @@
       "integrity": "sha1-jUu2j9GDDuBwM7HFpamkAhyWUpY=",
       "dev": true,
       "requires": {
-        "methods": "~1.1.2",
-        "superagent": "^3.0.0"
+        "methods": "1.1.2",
+        "superagent": "3.5.2"
       }
     },
     "supertest-as-promised": {
@@ -674,8 +682,8 @@
       "integrity": "sha1-c13NNwWhcIXbI131HYGJU8H7t6w=",
       "dev": true,
       "requires": {
-        "bluebird": "^1.2.4",
-        "methods": "^1.0.0"
+        "bluebird": "1.2.4",
+        "methods": "1.1.2"
       },
       "dependencies": {
         "bluebird": {
@@ -685,12 +693,6 @@
           "dev": true
         }
       }
-    },
-    "supports-color": {
-      "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
-      "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
-      "dev": true
     },
     "through": {
       "version": "2.3.8",
@@ -715,7 +717,7 @@
       "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "~2.1.15"
+        "mime-types": "2.1.15"
       }
     },
     "unpipe": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "chai": "^2.2.0",
-    "mocha": "^2.5.3",
+    "mocha": "^2.2.1",
     "sinon": "^1.14.1",
     "supertest": "*",
     "supertest-as-promised": "^1.0.0"


### PR DESCRIPTION
Reverts opendoor-labs/heroku-datadog-drain#5

This seems to have an issue with tag duplication
![screen shot 2019-01-04 at 7 03 22 pm](https://user-images.githubusercontent.com/4501235/50719591-78692f00-1053-11e9-96d1-1fff3a1114cc.png)
https://app.datadoghq.com/metric/explorer?live=false&page=0&is_auto=false&from_ts=1546648021314&to_ts=1546661333160&tile_size=m&exp_metric=heroku.dyno.load.avg.15m.avg&exp_scope=dynotype%3Aweb%2Capp%3Aopendoor-web&exp_group=dynotype&exp_agg=max&exp_row_type=metric#dyno:web.2

