### PR TITLE
deduplicate dyno metric tags

### DIFF
--- a/app.js
+++ b/app.js
@@ -61,10 +61,9 @@ function processLine (line, prefix, defaultTags) {
       dyno: line.source,
       dynotype: (line.source || '').split('.')[0]
     };
-    let defaultTagsDict = _.reduce(defaultTags, function(memo, tag) {
+    let defaultTagsDict = _.transform(defaultTags, function(result, tag) {
       let tagArr = tag.split(':');
-      memo[tagArr[0]] = tagArr[1];
-      return memo
+      result[tagArr[0]] = tagArr[1];
     }, {});
     let tags = tagsToArr(_.extend(defaultTagsDict, tagsDict));
     let metrics = _.pick(line, (_, key) => key.startsWith('sample#'));

--- a/app.js
+++ b/app.js
@@ -57,8 +57,16 @@ function processLine (line, prefix, defaultTags) {
     if (process.env.DEBUG) {
       console.log('Processing dyno metrics');
     }
-    let tags = tagsToArr({ dyno: line.source });
-    tags = _.union(tags, defaultTags);
+    let tagsDict = {
+      dyno: line.source,
+      dynotype: (line.source || '').split('.')[0]
+    };
+    let defaultTagsDict = _.reduce(defaultTags, function(memo, tag) {
+      let tagArr = tag.split(':');
+      memo[tagArr[0]] = tagArr[1];
+      return memo
+    }, {});
+    let tags = tagsToArr(_.extend(defaultTagsDict, tagsDict));
     let metrics = _.pick(line, (_, key) => key.startsWith('sample#'));
     _.forEach(metrics, function (value, key) {
       key = key.split('#')[1];

--- a/app.test.js
+++ b/app.test.js
@@ -42,15 +42,15 @@ describe('Heroku Datadog Drain', function () {
     .expect('OK')
     .then(function () {
       expect(StatsD.prototype.histogram.args).to.deep.equal([
-        ['heroku.router.request.connect', 1, ['dyno:web.1', 'method:POST', 'status:201', 'path:/users', 'host:myapp.com', 'at:info', 'default:tag', 'app:test-app']],
-        ['heroku.router.request.service', 37, ['dyno:web.1', 'method:POST', 'status:201', 'path:/users', 'host:myapp.com', 'at:info', 'default:tag', 'app:test-app']],
-        ['heroku.router.request.connect', 1, ['dyno:web.2', 'method:GET', 'status:200', 'path:/users/me/tasks', 'host:myapp.com', 'at:info', 'default:tag', 'app:test-app']],
-        ['heroku.router.request.service', 64, ['dyno:web.2', 'method:GET', 'status:200', 'path:/users/me/tasks', 'host:myapp.com', 'at:info', 'default:tag', 'app:test-app']],
-        ['heroku.router.request.connect', 6, ['dyno:web.1', 'method:GET', 'status:503', 'path:/', 'host:myapp.com', 'code:H12', 'desc:Request timeout', 'at:error', 'default:tag', 'app:test-app']],
-        ['heroku.router.request.service', 30001, ['dyno:web.1', 'method:GET', 'status:503', 'path:/', 'host:myapp.com', 'code:H12', 'desc:Request timeout', 'at:error', 'default:tag', 'app:test-app']],
+        ['heroku.router.request.connect', 1, ['dyno:web.1', 'path:/users', 'method:POST', 'status:201', 'host:myapp.com', 'at:info', 'default:tag', 'app:test-app']],
+        ['heroku.router.request.service', 37, ['dyno:web.1', 'path:/users', 'method:POST', 'status:201', 'host:myapp.com', 'at:info', 'default:tag', 'app:test-app']],
+        ['heroku.router.request.connect', 1, ['dyno:web.2', 'path:/users/me/tasks', 'method:GET', 'status:200', 'host:myapp.com', 'at:info', 'default:tag', 'app:test-app']],
+        ['heroku.router.request.service', 64, ['dyno:web.2', 'path:/users/me/tasks', 'method:GET', 'status:200', 'host:myapp.com', 'at:info', 'default:tag', 'app:test-app']],
+        ['heroku.router.request.connect', 6, ['dyno:web.1', 'path:/', 'method:GET', 'status:503', 'host:myapp.com', 'code:H12', 'desc:Request timeout', 'at:error', 'default:tag', 'app:test-app']],
+        ['heroku.router.request.service', 30001, ['dyno:web.1', 'path:/', 'method:GET', 'status:503', 'host:myapp.com', 'code:H12', 'desc:Request timeout', 'at:error', 'default:tag', 'app:test-app']],
       ]);
       expect(StatsD.prototype.increment.args).to.deep.equal([
-        ['heroku.router.error', 1, ['dyno:web.1', 'method:GET', 'status:503', 'path:/', 'host:myapp.com', 'code:H12', 'desc:Request timeout', 'at:error', 'default:tag', 'app:test-app']],
+        ['heroku.router.error', 1, ['dyno:web.1', 'path:/', 'method:GET', 'status:503', 'host:myapp.com', 'code:H12', 'desc:Request timeout', 'at:error', 'default:tag', 'app:test-app']],
       ]);
     });
   });
@@ -66,15 +66,15 @@ describe('Heroku Datadog Drain', function () {
     .expect('OK')
     .then(function () {
       expect(StatsD.prototype.histogram.args).to.deep.equal([
-        ['heroku.dyno.load.avg.1m', 0.01, ['dyno:web.1', 'default:tag', 'app:test-app']],
-        ['heroku.dyno.load.avg.5m', 0.02, ['dyno:web.1', 'default:tag', 'app:test-app']],
-        ['heroku.dyno.load.avg.15m', 0.03, ['dyno:web.1', 'default:tag', 'app:test-app']],
-        ['heroku.dyno.memory.total', 103.50, ['dyno:web.1', 'default:tag', 'app:test-app']],
-        ['heroku.dyno.memory.rss', 94.70, ['dyno:web.1', 'default:tag', 'app:test-app']],
-        ['heroku.dyno.memory.cache', 0.32, ['dyno:web.1', 'default:tag', 'app:test-app']],
-        ['heroku.dyno.memory.swap', 8.48, ['dyno:web.1', 'default:tag', 'app:test-app']],
-        ['heroku.dyno.memory.pgpgin', 36091, ['dyno:web.1', 'default:tag', 'app:test-app']],
-        ['heroku.dyno.memory.pgpgout', 11765, ['dyno:web.1', 'default:tag', 'app:test-app']]
+        ['heroku.dyno.load.avg.1m', 0.01, ['default:tag', 'app:test-app', 'dyno:web.1', 'dynotype:web']],
+        ['heroku.dyno.load.avg.5m', 0.02, ['default:tag', 'app:test-app', 'dyno:web.1', 'dynotype:web']],
+        ['heroku.dyno.load.avg.15m', 0.03, ['default:tag', 'app:test-app', 'dyno:web.1', 'dynotype:web']],
+        ['heroku.dyno.memory.total', 103.50, ['default:tag', 'app:test-app', 'dyno:web.1', 'dynotype:web']],
+        ['heroku.dyno.memory.rss', 94.70, ['default:tag', 'app:test-app', 'dyno:web.1', 'dynotype:web']],
+        ['heroku.dyno.memory.cache', 0.32, ['default:tag', 'app:test-app', 'dyno:web.1', 'dynotype:web']],
+        ['heroku.dyno.memory.swap', 8.48, ['default:tag', 'app:test-app', 'dyno:web.1', 'dynotype:web']],
+        ['heroku.dyno.memory.pgpgin', 36091, ['default:tag', 'app:test-app', 'dyno:web.1', 'dynotype:web']],
+        ['heroku.dyno.memory.pgpgout', 11765, ['default:tag', 'app:test-app', 'dyno:web.1', 'dynotype:web']]
       ]);
     });
   });


### PR DESCRIPTION
Signed-off-by: Maggie Moreno <maggie.moreno@opendoor.com>

Add dynotype tag. Deduplicate new default tags dyno and dynotype, which are just set to "web" instead of something useful. Fix tests.