### PR TITLE
add prerun script to comment out default dyno tags

### DIFF
--- a/datadog/prerun.sh
+++ b/datadog/prerun.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Disable the Datadog Agent for datadog drain run machines
+if [ "$DYNOTYPE" == "run" ]; then
+  DISABLE_DATADOG_AGENT="true"
+fi
+
+# Comment out Datadog agent default host tags-- we have our own
+sed -i 's/- dyno:/# - dyno:/' "$DATADOG_CONF"
+sed -i 's/- dynotype:/# - dynotype:/' "$DATADOG_CONF"


### PR DESCRIPTION
Signed-off-by: Maggie Moreno <maggie.moreno@opendoor.com>

The Datadog Heroku buildpack adds tags for dyno and dynotype to all metrics coming from a given machine, see https://github.com/DataDog/heroku-buildpack-datadog/blob/master/extra/datadog.sh#L41-L59. This is problematic for our datadog-drain machines, where we want the metrics emitted to be tagged with the source dyno and dynotype, not the reporting datadog-drain machine (which reports as `dyno:web.X` and `dynotype:dyno`).

The Datadog Heroku buildpack says that we can add a prerun script to alert configs and other variables, see https://github.com/DataDog/heroku-buildpack-datadog#prerun-script. So I'm adding this script to disable the Datadog agent on run datadog-drain `run` machines and to comment out the added dyno and dynotype tags.