### PR TITLE
correct regex for dyno errors

### DIFF
--- a/app.js
+++ b/app.js
@@ -82,7 +82,7 @@ function processLine (line, prefix, defaultTags) {
       if (k.match(/^[HRL]\d+$/) && v === true) {
         // Add error code
         customTags['code'] = k;
-      } else if (k.match(/^\w+\.\d+$/) && v === true) {
+      } else if (k.match(/^[a-zA-Z_]+\.\d+$/) && v === true) {
         // Add dyno name
         customTags['dyno'] = k;
         customTags['dynotype'] = k.split('.')[0];


### PR DESCRIPTION
Signed-off-by: Maggie Moreno <maggie.moreno@opendoor.com>

Fixes weird dyno tags
![screen shot 2019-01-10 at 3 52 36 pm](https://user-images.githubusercontent.com/4501235/51004507-d08ab000-14ef-11e9-8f55-bfa41dccaddb.png)
