### PR TITLE
remove path info from heroku.router.request.* metrics

### DIFF
--- a/app.js
+++ b/app.js
@@ -100,7 +100,7 @@ function processLine (line, prefix, defaultTags) {
     if (process.env.DEBUG) {
       console.log('Processing router metrics');
     }
-    let tags = tagsToArr(_.pick(line, ['dyno', 'path', 'method', 'status', 'host', 'code', 'desc', 'at']));
+    let tags = tagsToArr(_.pick(line, ['dyno', 'status', 'host', 'code', 'desc', 'at']));
     tags = _.union(tags, defaultTags);
     statsd.histogram(prefix + 'heroku.router.request.connect', extractNumber(line.connect), tags);
     statsd.histogram(prefix + 'heroku.router.request.service', extractNumber(line.service), tags);

--- a/app.test.js
+++ b/app.test.js
@@ -42,15 +42,15 @@ describe('Heroku Datadog Drain', function () {
     .expect('OK')
     .then(function () {
       expect(StatsD.prototype.histogram.args).to.deep.equal([
-        ['heroku.router.request.connect', 1, ['dyno:web.1', 'path:/users', 'method:POST', 'status:201', 'host:myapp.com', 'at:info', 'default:tag', 'app:test-app']],
-        ['heroku.router.request.service', 37, ['dyno:web.1', 'path:/users', 'method:POST', 'status:201', 'host:myapp.com', 'at:info', 'default:tag', 'app:test-app']],
-        ['heroku.router.request.connect', 1, ['dyno:web.2', 'path:/users/me/tasks', 'method:GET', 'status:200', 'host:myapp.com', 'at:info', 'default:tag', 'app:test-app']],
-        ['heroku.router.request.service', 64, ['dyno:web.2', 'path:/users/me/tasks', 'method:GET', 'status:200', 'host:myapp.com', 'at:info', 'default:tag', 'app:test-app']],
-        ['heroku.router.request.connect', 6, ['dyno:web.1', 'path:/', 'method:GET', 'status:503', 'host:myapp.com', 'code:H12', 'desc:Request timeout', 'at:error', 'default:tag', 'app:test-app']],
-        ['heroku.router.request.service', 30001, ['dyno:web.1', 'path:/', 'method:GET', 'status:503', 'host:myapp.com', 'code:H12', 'desc:Request timeout', 'at:error', 'default:tag', 'app:test-app']],
+        ['heroku.router.request.connect', 1, ['dyno:web.1', 'status:201', 'host:myapp.com', 'at:info', 'default:tag', 'app:test-app']],
+        ['heroku.router.request.service', 37, ['dyno:web.1', 'status:201', 'host:myapp.com', 'at:info', 'default:tag', 'app:test-app']],
+        ['heroku.router.request.connect', 1, ['dyno:web.2', 'status:200', 'host:myapp.com', 'at:info', 'default:tag', 'app:test-app']],
+        ['heroku.router.request.service', 64, ['dyno:web.2', 'status:200', 'host:myapp.com', 'at:info', 'default:tag', 'app:test-app']],
+        ['heroku.router.request.connect', 6, ['dyno:web.1', 'status:503', 'host:myapp.com', 'code:H12', 'desc:Request timeout', 'at:error', 'default:tag', 'app:test-app']],
+        ['heroku.router.request.service', 30001, ['dyno:web.1', 'status:503', 'host:myapp.com', 'code:H12', 'desc:Request timeout', 'at:error', 'default:tag', 'app:test-app']],
       ]);
       expect(StatsD.prototype.increment.args).to.deep.equal([
-        ['heroku.router.error', 1, ['dyno:web.1', 'path:/', 'method:GET', 'status:503', 'host:myapp.com', 'code:H12', 'desc:Request timeout', 'at:error', 'default:tag', 'app:test-app']],
+        ['heroku.router.error', 1, ['dyno:web.1', 'status:503', 'host:myapp.com', 'code:H12', 'desc:Request timeout', 'at:error', 'default:tag', 'app:test-app']],
       ]);
     });
   });


### PR DESCRIPTION
Signed-off-by: Maggie Moreno <maggie.moreno@opendoor.com>

Since the `path` tag on this metric has over 2K values, and we already have `web.request.*` metrics with timing info, this tag seems like duplicate information. Also, our Datadog bill arrived recently with a few unique-metrics volume surprises and I wanted to do what I could to knock out the low-hanging fruit.

Without the `path` tag, the `method` tag seems a little silly.